### PR TITLE
Fixed some rendering issues.

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.1.4/semantic.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/react-router/0.13.3/ReactRouter.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.1/lodash.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.0.0/lodash.min.js"></script>
   </head>
   <body>
     <div id="content"></div>

--- a/moroScript.jsx
+++ b/moroScript.jsx
@@ -110,7 +110,7 @@
 
     //Remove punctuation from string excluding dashes and period in word
     function removePunc(word) {
-        var rtnWord = word.replace(/[,\/#?!\"\“$%\^&\*;:{}=_`~()]/g,"");
+        var rtnWord = word.replace(/[,\/#?!\"\“\”$%\^&\*;:{}=_`~()]/g,"");
         rtnWord = rtnWord.replace(/\b[.]+\B|\B[.]+\b/g, "");
         return rtnWord;
     }
@@ -154,9 +154,9 @@
             }
         }
     //Print out result dict
-    console.log("*********")
-    console.log(JSON.stringify(results))
-    console.log("*********")
+    //console.log("*********")
+    //console.log(JSON.stringify(results))
+    //console.log("*********")
     //return morphemes/glosses by moro morphemes
     return _.sortBy (results, function(j) {
       return j.moroword;
@@ -207,9 +207,9 @@
       var Definition = React.createClass({
         render: function() {
           return (
-            <div>
+            <div className="ui vertical segment">
               <h2>
-                {this.props.moroword}
+                {_.join(this.props.moroword, ", ")}
               </h2>
               {this.props.definition}
             </div>
@@ -241,9 +241,9 @@
         },
         render: function() {
           if (this.state.loaded) {
+            //TODO: rendering all definitions is slow, so we only render 10000 for now. Add pagination before rendering all. @HSande
             return (
              <div>
-                //TODO: rendering all definitions is slow, so we only render 100 for now. Add pagination before rendering all. @HSande
                 Dictionary({this.state.data.length}): <DictList data={this.state.data.slice(0,10000)}/>
               </div>
             );


### PR DESCRIPTION
Added semantic ui vertical segments to better differentiate the definitions,
also rendered the lists as comma separated lists of words. `_.join` was new in
lodash 4.0.0, so updated to that version of the library.
