### PR TITLE
Make just one schwa character in the database

### DIFF
--- a/moroScript.jsx
+++ b/moroScript.jsx
@@ -136,7 +136,12 @@
         //example: g-a-s-o; clg-rtc-eat.rt-pfv = [g-, a-, s, -o]; [clg-, rtc-, eat.rt, -pfv]
         for (var i = 0; i < glosses.length; i++) {
           var gloss = removePunc(glosses[i].toLowerCase());
-          var morpheme = removePunc(morphemes[i].toLowerCase());
+          // Remove punctuation, make lower case, and replace all "Latin Letter
+          // Small Schwa" characters with "Latin Letter Smal E" characters, so
+          // there is just one schwa character in the corpus. 
+          var morpheme =
+            removePunc(morphemes[i].toLowerCase().replace(/\u0259/g,'\u01DD'))
+         
           if (gloss.match(/^[0-9]*$/)){
             continue
           }


### PR DESCRIPTION
Fix a bug where two schwas were appearing. Replaced all unicode
characters \u0259 (Latin Small Letter Schwa) with \u01DD (Latin Small
Letter Turned E).

Chose the turned e over the schwa because it looked a bit more congruent
with the font of the rest of the charactes, but this is arbitrary.
Changing the order of the two '\u' arguments in the .replace function
would reverse this.